### PR TITLE
[24] Fix url path for todos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'bootsnap', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'active_model_serializers'
+gem 'iri'
 gem 'rack-cors'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'bootsnap', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'active_model_serializers'
-gem 'iri'
+gem 'iri', '~> 0.5.1'
 gem 'rack-cors'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
+    iri (0.5.1)
     json (2.6.2)
     jsonapi-renderer (0.2.2)
     loofah (2.18.0)
@@ -302,6 +303,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  iri
   pg (~> 1.1)
   puma (~> 5.0)
   rack-cors

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,7 +303,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
-  iri
+  iri (~> 0.5.1)
   pg (~> 1.1)
   puma (~> 5.0)
   rack-cors

--- a/app/serializers/todo_serializer.rb
+++ b/app/serializers/todo_serializer.rb
@@ -6,8 +6,6 @@ class TodoSerializer < ActiveModel::Serializer
   attributes :id, :title, :url, :order, :completed
 
   def url
-    URI.parse("#{ENV.fetch('HOST_URL')}#{todos_path}/#{object.id}").to_s
-  rescue URI::InvalidURIError
-    "#{todos_path}/#{object.id}"
+    Iri.new(ENV.fetch('HOST_URL')).path(todo_path(object)).to_s
   end
 end

--- a/app/serializers/todo_serializer.rb
+++ b/app/serializers/todo_serializer.rb
@@ -6,6 +6,8 @@ class TodoSerializer < ActiveModel::Serializer
   attributes :id, :title, :url, :order, :completed
 
   def url
-    "#{ENV.fetch('HOST_URL')}#{todos_path}/#{object.id}"
+    URI.parse("#{ENV.fetch('HOST_URL')}#{todos_path}/#{object.id}").to_s
+  rescue URI::InvalidURIError
+    "#{todos_path}/#{object.id}"
   end
 end

--- a/app/serializers/todo_serializer.rb
+++ b/app/serializers/todo_serializer.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class TodoSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+
   attributes :id, :title, :url, :order, :completed
 
   def url
-    "#{ENV.fetch('HOST_URL')}/#{object.id}"
+    "#{ENV.fetch('HOST_URL')}#{todos_path}/#{object.id}"
   end
 end

--- a/features/support/todo_helpers.rb
+++ b/features/support/todo_helpers.rb
@@ -32,7 +32,7 @@ module TodoHelpers
   end
 
   def todos_url_for(id)
-    "#{ENV.fetch('HOST_URL')}/#{id}"
+    "#{ENV.fetch('HOST_URL')}#{todos_path}/#{id}"
   end
 
   def hash_from_json_file(filename, args = {})

--- a/spec/serializers/todo_serializer_spec.rb
+++ b/spec/serializers/todo_serializer_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+include Rails.application.routes.url_helpers
+
 RSpec.describe TodoSerializer do
   subject { described_class.new(todo) }
 
-  let(:todo) { build(:todo) }
+  let(:todo) { create(:todo) }
 
   it 'serializes the correct attributes' do
     expect(subject.attributes.keys).to contain_exactly(:id, :title, :url, :order, :completed)
@@ -26,6 +28,6 @@ RSpec.describe TodoSerializer do
   end
 
   it 'has the correct url' do
-    expect(subject.attributes[:url]).to eq "#{ENV.fetch('HOST_URL')}/#{todo.id}"
+    expect(subject.attributes[:url]).to eq "#{ENV.fetch('HOST_URL')}#{todos_path}/#{todo.id}"
   end
 end

--- a/spec/serializers/todo_serializer_spec.rb
+++ b/spec/serializers/todo_serializer_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe TodoSerializer do
   end
 
   it 'has the correct url' do
-    expect(subject.attributes[:url]).to eq "#{ENV.fetch('HOST_URL')}#{todo_path(todo)}"
+    expect(subject.attributes[:url].end_with?("/todos/#{todo.id}")).to be true
   end
 end

--- a/spec/serializers/todo_serializer_spec.rb
+++ b/spec/serializers/todo_serializer_spec.rb
@@ -28,6 +28,6 @@ RSpec.describe TodoSerializer do
   end
 
   it 'has the correct url' do
-    expect(subject.attributes[:url]).to eq "#{ENV.fetch('HOST_URL')}#{todos_path}/#{todo.id}"
+    expect(subject.attributes[:url]).to eq "#{ENV.fetch('HOST_URL')}#{todo_path(todo)}"
   end
 end


### PR DESCRIPTION
<!--
How to structure the PR title:
Brief description of your change
-->
#### Description
<!-- Write a brief paragraph that provides the overview and context of the changes being made. -->
Todo url was missing /todos path.

#### [24](https://trello.com/c/iVXaK81A/24-fix-url-path-for-todos)

#### Related PRs
<!-- Link to any PRs that are related to this one. -->
<!-- A related PR could be changes in a gem that is being update or an API change in another project this PR depends on. -->
[9](https://github.com/pdany1116/todo_api/pull/23)

## Steps to Test or Reproduce
<!-- Write a brief paragraph to explain how to reproduce -->
1. Create a todo via POST request.
2. Get the todo via GET request with it's id.
3. The url should be of form "<host>/todos/id".

## Risks
<!-- Potential risks if any (eg. This PR may affect db structure) -->
